### PR TITLE
Precision metadata: reproducibility + per-body errors (hybrid builder)

### DIFF
--- a/constants/validation.js
+++ b/constants/validation.js
@@ -1,0 +1,42 @@
+module.exports = {
+  VALIDATION: {
+    authority: 'NASA JPL HORIZONS',
+    date: '2025-10-26',
+    url: 'https://github.com/mojoatomic/antikythera-engine-2/blob/main/docs/VALIDATION.md',
+
+    // From single validation run
+    span: {
+      start: '2025-10-26',
+      end: '2025-10-26',
+    },
+    sample_count: 7, // 7 bodies × 1 timestamp
+
+    // Aggregate statistics
+    aggregate: {
+      typical_arcsec: 1.4,  // p50 across lon/lat
+      max_arcsec: 8.6,
+      p50_arcsec: 1.4,
+      p95_arcsec: null,
+    },
+
+    // Per-body max absolute errors (arcsec) for precision=full
+    bodies: {
+      sun: { lon: 0.4, lat: 0.7 },
+      moon: { lon: 1.9, lat: 0.3 },
+      mercury: { lon: 1.4, lat: 2.1 },
+      venus: { lon: 1.1, lat: 0.3 },
+      mars: { lon: 0.5, lat: 1.6 },
+      jupiter: { lon: 2.8, lat: 1.1 },
+      saturn: { lon: 8.6, lat: 0.5 },
+    },
+  },
+
+  CONVENTIONS: {
+    coordinate_frame: 'J2000 ecliptic',
+    calculation_method: 'astronomy-engine (VSOP87/ELP2000)',
+    angle_units: 'degrees',
+    error_units: 'arcsec',
+    longitude_wrap: '[0,360)',
+    apparent: true,
+  },
+};

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,6 +1,6 @@
 module.exports = [
   {
-    ignores: ['node_modules/**', 'coverage/**', '**/*.test.js']
+    ignores: ['node_modules/**', 'coverage/**', '**/*.test.js', 'precision-metadata-package/**']
   },
   {
     files: ['**/*.js'],

--- a/utils/metadata.js
+++ b/utils/metadata.js
@@ -1,0 +1,39 @@
+const { execSync } = require('child_process');
+const path = require('path');
+
+function readPackageJson() {
+  try {
+    // Resolve package.json from project root
+    // __dirname is utils/, package.json is one level up
+    // Avoid require cache to allow runtime updates if any
+    return require(path.join(__dirname, '..', 'package.json'));
+  } catch (_e) {
+    return { version: '0.0.0', dependencies: {} };
+  }
+}
+
+function getGitSha() {
+  if (process.env.GIT_SHA && String(process.env.GIT_SHA).trim()) {
+    return String(process.env.GIT_SHA).trim();
+  }
+  try {
+    return execSync('git rev-parse --short HEAD', { encoding: 'utf8' }).trim();
+  } catch (_err) {
+    return 'unknown';
+  }
+}
+
+function getEngineVersion(pkg) {
+  const dep = pkg.dependencies && pkg.dependencies['astronomy-engine'];
+  if (!dep) return 'astronomy-engine vunknown';
+  const cleaned = dep.replace(/^[^0-9]*/, '');
+  return `astronomy-engine v${cleaned}`;
+}
+
+const pkg = readPackageJson();
+
+module.exports = {
+  API_VERSION: pkg.version || '0.0.0',
+  ENGINE_VERSION: getEngineVersion(pkg),
+  GIT_SHA: getGitSha(),
+};

--- a/utils/precision-builder.js
+++ b/utils/precision-builder.js
@@ -1,0 +1,87 @@
+const { VALIDATION, CONVENTIONS } = require('../constants/validation');
+const { API_VERSION, ENGINE_VERSION, GIT_SHA } = require('./metadata');
+
+function buildPrecisionMetadata() {
+  return {
+    validated_against: VALIDATION.authority,
+    validation_date: VALIDATION.date,
+    coordinate_frame: CONVENTIONS.coordinate_frame,
+    calculation_method: CONVENTIONS.calculation_method,
+    typical_error_arcsec: VALIDATION.aggregate.typical_arcsec,
+    max_error_arcsec: VALIDATION.aggregate.max_arcsec,
+    validation_url: VALIDATION.url,
+    error_quantiles_arcsec: {
+      p50: VALIDATION.aggregate.p50_arcsec,
+      p95: VALIDATION.aggregate.p95_arcsec,
+      max: VALIDATION.aggregate.max_arcsec,
+    },
+  };
+}
+
+function buildReproducibilityMetadata() {
+  return {
+    api_version: API_VERSION,
+    engine_version: ENGINE_VERSION,
+    git_sha: GIT_SHA,
+    validation_span: {
+      start: VALIDATION.span.start,
+      end: VALIDATION.span.end,
+    },
+    sample_count: VALIDATION.sample_count,
+    conventions: {
+      angle_units: CONVENTIONS.angle_units,
+      error_units: CONVENTIONS.error_units,
+      longitude_wrap: CONVENTIONS.longitude_wrap,
+      apparent: CONVENTIONS.apparent,
+      frame: CONVENTIONS.coordinate_frame,
+    },
+  };
+}
+
+function addPerBodyErrors(coords) {
+  const result = {};
+  for (const [bodyName, coord] of Object.entries(coords)) {
+    const bodyErrors = VALIDATION.bodies[bodyName];
+    result[bodyName] = { lon: coord.lon, lat: coord.lat };
+    if (bodyErrors) {
+      result[bodyName].validated_error = {
+        lon_arcsec: bodyErrors.lon,
+        lat_arcsec: bodyErrors.lat,
+        lon_p95_arcsec: null,
+        lat_p95_arcsec: null,
+        max_arcsec: VALIDATION.aggregate.max_arcsec,
+      };
+    }
+  }
+  return result;
+}
+
+function buildSystemMetadata(options) {
+  const {
+    cached = false,
+    computationTime = 0,
+    fullPrecision = false,
+    eclipticCoords = {},
+    debugData = {},
+  } = options;
+
+  const system = {
+    healthy: true,
+    cached,
+    computation_time_ms: computationTime,
+    precision: buildPrecisionMetadata(),
+    reproducibility: buildReproducibilityMetadata(),
+    debug: {
+      ...debugData,
+      ecliptic_coordinates: fullPrecision ? addPerBodyErrors(eclipticCoords) : eclipticCoords,
+    },
+  };
+  return system;
+}
+
+module.exports = {
+  buildPrecisionMetadata,
+  buildReproducibilityMetadata,
+  addPerBodyErrors,
+  buildSystemMetadata,
+};


### PR DESCRIPTION
Implements precision metadata across /api/display and new /api/system. Adds:\n- system.precision: validation authority/date, frame, method, error quantiles (p50, p95=null, max)\n- system.reproducibility: api_version, astronomy-engine version, git_sha, validation span, sample_count, conventions\n- ?precision=full: per-body validated_error for ecliptic_coordinates (lon/lat arcsec)\n- observer sources: query | ip_geolocation | fallback; kept at system.observer (nested)\n- utils/precision-builder.js for modular construction; lint-clean\nNo breaking changes; defaults are additive and lightweight.