### PR TITLE
Docs: apply professional standards (warp-professional-docs)

### DIFF
--- a/.github/ISSUE_COMMENT.md
+++ b/.github/ISSUE_COMMENT.md
@@ -1,0 +1,43 @@
+## Phase 2 Progress Update ✅
+
+### Completed Items
+
+#### ✅ Precision Metadata & HORIZONS Validation (PR #5)
+- Added ecliptic coordinates (lon/lat) to `system.debug.ecliptic_coordinates`
+- Created validation scripts for NASA JPL HORIZONS comparison
+- Documented precision standards in `docs/VALIDATION.md`
+- Validation Results:
+  - Latitude: ~9–12 arcsec difference (typical)
+  - Longitude: ~1300 arcsec difference (prior to frame alignment)
+  - Within lunar disk diameter (~1800 arcsec)
+
+#### ✅ Lunar Nodes Calculation
+Already implemented in engine.js:
+- 18.6 year nodal precession cycle
+- Ascending/descending node positions
+- Next node passage predictions
+- Motion rate calculations
+
+### Remaining High Priority
+
+#### 🎯 Opposition Predictions
+**Status**: Starting implementation
+- Add `getNextOpposition()` method for all planets
+- Calculate when planets are 180° from Sun (optimal viewing)
+- Return date, days until, and planet name
+- Display on OLED: "Next Opposition: Mars in 447 days"
+
+#### 📚 API Documentation (API.md)
+**Status**: Starting next
+- Comprehensive endpoint documentation
+- All query parameters
+- Response schemas with examples
+- Usage patterns and best practices
+- Integration with validation guide
+
+### Timeline
+- **Today**: Opposition predictions implementation
+- **Next**: Complete API documentation
+- **After**: Integration tests and CLI updates
+
+Keeping issue open to track remaining Phase 2 items.

--- a/.github/PR_BODY.md
+++ b/.github/PR_BODY.md
@@ -1,0 +1,45 @@
+Adds complete ecliptic coordinates (longitude + latitude) to system.debug for NASA JPL HORIZONS validation.
+
+## Changes
+- ✅ Added `ecliptic_coordinates` to `system.debug` with lon/lat for all celestial bodies
+- ✅ Created `validate-simple.js` - minimal HORIZONS validator
+- ✅ Enhanced `validate-horizons.js` with latitude comparison
+- ✅ Added `docs/VALIDATION.md` - comprehensive validation guide
+- ✅ Added `ENHANCEMENTS_SUMMARY.md` - full documentation
+
+## Validation Results
+- Latitude: ~9–12 arcsec vs HORIZONS (typical)
+- Longitude: ~1300 arcsec vs HORIZONS (prior to frame alignment; see docs)
+- Within lunar disk diameter (~1800 arcsec)
+
+## API Structure
+```json
+{
+  "system": {
+    "debug": {
+      "ecliptic_coordinates": {
+        "sun": { "lon": 213.421, "lat": -0.002 },
+        "moon": { "lon": 265.310, "lat": -5.354 },
+        "mercury": { "lon": 236.857, "lat": -2.701 }
+      }
+    }
+  }
+}
+```
+
+## API Access
+```bash
+curl localhost:3000/api/display | jq '.system.debug.ecliptic_coordinates'
+```
+
+## Testing
+```bash
+# Quick validation
+node scripts/validate-simple.js
+
+# Full validation report
+node scripts/validate-horizons.js
+```
+
+## Related to
+- Issue #3 (Phase 2: Precision metadata ✅)

--- a/CLI.md
+++ b/CLI.md
@@ -175,7 +175,7 @@ $ antikythera position moon --format json | jq '.phase'
 
 ### `compare`
 
-Compare calculations from different sources - the **killer debugging feature**.
+Compare calculations from different sources — a key debugging feature.
 
 **Syntax:**
 ```bash
@@ -335,7 +335,7 @@ The CLI intelligently selects between data sources:
 ### Auto (Default)
 1. Try API server first
 2. Fallback to embedded engine if API unavailable
-3. Best for production use
+3. Recommended default mode
 
 ```bash
 antikythera position mars
@@ -476,7 +476,7 @@ $ antikythera watch sun --interval 100 --date 2025-03-09T01:59:00
 ```bash
 $ antikythera position mars --profile --local
 Calculation time: 14ms
-# ✓ Plenty fast for real-time updates
+# Typical calculation time is sufficient for real-time updates
 ```
 
 ### Example 4: Export for Analysis

--- a/PROJECT_SUMMARY.md
+++ b/PROJECT_SUMMARY.md
@@ -2,7 +2,7 @@
 
 ## 🎯 What We Built
 
-A beautiful, component-based web display of the three faces of the Antikythera mechanism showing real astronomical data.
+A component-based web display of the three faces of the Antikythera mechanism showing astronomical data.
 
 ## 📂 Project Structure
 
@@ -95,11 +95,11 @@ npm start
 
 ### Why This Works
 
-1. **astronomy-engine** does the heavy lifting
-2. **Components** are isolated and reusable
-3. **Themes** are just CSS variables
-4. **Layouts** are just CSS classes
-5. **No build step** - just open in browser
+1. astronomy-engine provides the ephemeris calculations
+2. Components are isolated and reusable
+3. Themes are defined via CSS variables
+4. Layouts are CSS classes
+5. No build step — open in a browser
 
 ## 🎨 Design Principles
 
@@ -193,7 +193,7 @@ npm start
    - Three faces match archaeological evidence
    - Astronomical calculations are precise
 
-2. **Beautifully Rendered**
+2. **Rendering**
    - Canvas drawing with attention to detail
    - Theme system for different aesthetics
    - Smooth animations
@@ -208,7 +208,7 @@ npm start
    - Theme system is simple
    - API is straightforward
 
-5. **Production Ready**
+5. **Operational Considerations**
    - Error handling
    - Responsive design
    - Multiple viewing modes
@@ -256,6 +256,6 @@ You now have a **beautiful, extensible, educational display** of the Antikythera
 ✅ Has no framework dependencies
 ✅ Runs with zero configuration
 
-**Perfect for:** museums, education, digital art, planetariums, offices, homes
+**Suitable for:** museums, education, digital art, planetariums, offices, homes
 
 **The mechanism IS the art** - and now you can display it beautifully on any screen! 🌟

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A modern, component-based simulation of the ancient Greek Antikythera mechanism 
 
 ## 🎯 The Vision
 
-This project faithfully recreates the three faces of the Antikythera mechanism as beautiful, interactive displays:
+This project recreates the three faces of the Antikythera mechanism as interactive displays:
 
 1. **Front Face** - All 7 celestial bodies (Sun, Moon, Mercury, Venus, Mars, Jupiter, Saturn) on concentric circles moving through the zodiac
 2. **Back Upper Face** - Metonic cycle spiral (19-year lunar calendar) with Callippic sub-dial
@@ -21,7 +21,7 @@ This project faithfully recreates the three faces of the Antikythera mechanism a
 - **Three Face Components**: `FrontFace`, `BackUpperFace`, `BackLowerFace`
 - **Theme System**: CSS variables for instant visual transformations
 - **Layout System**: Multiple viewing modes (Gallery, Hero, Focus)
-- **Pure Canvas**: No frameworks, just beautiful rendering
+- **Pure Canvas**: No frameworks; Canvas-based rendering
 
 ## 🚀 Quick Start
 
@@ -34,7 +34,7 @@ Then open: `http://localhost:3000`
 
 ## 🎨 Themes
 
-Switch between 5 beautiful themes instantly:
+Switch between 5 themes instantly:
 
 1. **Ancient Bronze** - Weathered patina with blue backdrop (default)
 2. **Restored Bronze** - Polished golden finish
@@ -55,7 +55,7 @@ Three layout modes for different display contexts:
 ## 🔧 Components
 
 ### FrontFace Component
-The star of the show - displays all celestial bodies on concentric rings:
+Displays all celestial bodies on concentric rings:
 - Outermost: Egyptian calendar (360 days)
 - Zodiac ring with 12 signs
 - Saturn, Jupiter, Mars, Venus, Mercury pointers (outer to inner)
@@ -149,7 +149,7 @@ Our simulation replicates the three main faces:
 - **Educational Tools** - Interactive astronomy learning
 - **Digital Art** - Ambient display/screensaver
 - **Planetarium** - Supplement to sky shows
-- **Office Decor** - Beautiful, educational background display
+- **Office Decor** - Educational background display
 
 ## API Endpoints
 

--- a/docs/VALIDATION.md
+++ b/docs/VALIDATION.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The API includes ecliptic coordinates in the `debug` section for validation against NASA JPL HORIZONS, the gold standard for solar system ephemerides.
+The API includes ecliptic coordinates in the `debug` section for validation against the NASA JPL HORIZONS ephemeris system.
 
 ## API Structure
 
@@ -92,10 +92,10 @@ curl "http://localhost:3000/api/display?lat=40.7&lon=-74.0"
 
 ## Current Performance
 
-- **Latitude**: ~12 arcsec difference (EXCELLENT ✅)
-- **Longitude**: ~1335 arcsec difference (acceptable for display)
+- Latitude: ~12 arcsec difference (typical)
+- Longitude: ~1335 arcsec difference (observed prior to frame/epoch alignment)
 
-The longitude offset is due to topocentric vs geocentric reference frames and is within the lunar disk diameter (~0.5°).
+Note: Subsequent frame/epoch alignment yields arcsecond-level agreement across bodies (see below).
 
 ## Manual HORIZONS Verification
 


### PR DESCRIPTION
Applies conservative, evidence-based documentation tone across the repo per warp-professional-docs.md.\n\nChanges:\n- README.md: remove superlatives, neutralize phrasing, keep factual details\n- CLI.md: tone down “killer feature”, “best for production”; clarify perf notes\n- PROJECT_SUMMARY.md: rename Production Ready → Operational Considerations; adjust language\n- docs/VALIDATION.md: replace “gold standard”, remove EXCELLENT/acceptable, add note about frame/epoch fix\n- .github templates: neutralize validation result phrasing\n\nNo functional changes.