### PR TITLE
Remove zodiac division lines from front face

### DIFF
--- a/public/components/FrontFace.js
+++ b/public/components/FrontFace.js
@@ -520,14 +520,6 @@ class FrontFace {
       
       // Zodiac symbol
       this.ctx.fillText(this.zodiacSigns[i].symbol, x, y);
-      
-      // Major division lines (30° boundaries)
-      this.ctx.strokeStyle = 'var(--color-accent, #d4af37)';
-      this.ctx.lineWidth = 3;
-      this.ctx.beginPath();
-      this.ctx.moveTo(this.centerX + Math.cos(angle) * (radius - 30), this.centerY + Math.sin(angle) * (radius - 30));
-      this.ctx.lineTo(this.centerX + Math.cos(angle) * (radius + 10), this.centerY + Math.sin(angle) * (radius + 10));
-      this.ctx.stroke();
     }
   }
   


### PR DESCRIPTION
## Fix

Removes the 12 division lines that were drawn through the zodiac symbols on the front face display.

## Changes
- Removed lines 524-530 in `public/components/FrontFace.js`
- The zodiac symbols (♈ ♉ ♊ ♋ ♌ ♍ ♎ ♏ ♐ ♑ ♒ ♓) are now displayed without diagonal lines crossing through them

## Visual Impact
- Cleaner zodiac ring display
- Zodiac symbols more readable
- No functional impact on astronomical calculations
