### PR TITLE
UI: Add year to date display (Month DD, YYYY)

### DIFF
--- a/public/components/FrontFace.js
+++ b/public/components/FrontFace.js
@@ -803,11 +803,19 @@ class FrontFace {
     }
     
     if (data.egyptianCalendar) {
-      const monthName = languageManager.getMonthName(data.egyptianCalendar.month);
+      // Show full Gregorian date with year, using observer timezone when available
+      const tz = data?.observer?.timezone;
+      const dateObj = new Date(data.date);
+      const dateStr = dateObj.toLocaleDateString('en-US', {
+        timeZone: tz || undefined,
+        month: 'long',
+        day: 'numeric',
+        year: 'numeric'
+      });
       this.ctx.font = '11px Georgia';
       this.ctx.fillStyle = 'rgba(240, 230, 210, 0.8)';
       this.ctx.fillText(
-        `${monthName} ${data.egyptianCalendar.day}`,
+        dateStr,
         padding,
         this.canvas.height - padding - lineHeight
       );


### PR DESCRIPTION
Adds year to lower-left date label so full date shows as "Month DD, YYYY" (e.g., "October 29, 2025"). Uses observer timezone when available.

- FrontFace: replace month/day string with `toLocaleDateString('en-US', { month:'long', day:'numeric', year:'numeric' })`
- Preserves styling/position; prevents DST issues by formatting from `data.date` with optional observer tz

Testing:
- Normal: npm start → shows full date
- Control: `antikythera control time 1969-07-20T20:17:00Z` → shows "July 20, 1969"

This is prep for control mode date context.