### PR TITLE
Use observer timezone for currentTime label in FrontFace.js

### DIFF
--- a/public/components/FrontFace.js
+++ b/public/components/FrontFace.js
@@ -825,12 +825,19 @@ class FrontFace {
     this.ctx.textAlign = 'right';
     let lowerRightY = this.canvas.height - padding;
     
-    // Real-time clock
-    if (data.currentTime) {
+    // Real-time clock (format using observer timezone when available)
+    {
+      const tz = data && data.observer && data.observer.timezone ? data.observer.timezone : undefined;
+      const now = new Date();
+      const timeStr = now.toLocaleTimeString('en-US', {
+        timeZone: tz || undefined,
+        hour: '2-digit', minute: '2-digit', second: '2-digit',
+        hour12: false,
+      });
       this.ctx.fillStyle = 'var(--color-pointer, #ffaa00)';
       this.ctx.font = 'bold 16px "Courier New", monospace';
       this.ctx.fillText(
-        data.currentTime,
+        timeStr,
         this.canvas.width - padding,
         lowerRightY - lineHeight * 3
       );


### PR DESCRIPTION
Minor UI fix: current time label now uses the observer timezone instead of the browser timezone.

Changes
- FrontFace.js: format real-time clock with data.observer.timezone when available (falls back to browser TZ).
- No changes to UTC-based geometry; hour markers and EoT logic remain UTC-safe.

Rationale
- Aligns display consistency with sunrise/sunset and date labels that already use observer timezone.
- Addresses the identified gap from the UTC/timezone audit.

Testing
- Lint passes.
- Test suites pass locally (including e2e).

Request
- Please review and merge.