### PR TITLE
Simplify showSunriseSunset checks and expand variable names

### DIFF
--- a/public/components/FrontFace.js
+++ b/public/components/FrontFace.js
@@ -268,10 +268,10 @@ class FrontFace {
         this.ctx.fillStyle = 'rgba(255, 107, 53, 0.9)';
         this.ctx.textAlign = 'center';
         this.ctx.textBaseline = 'middle';
-        const srLabelR = outerRingRadius + 28;
-        const srLabelX = this.centerX + Math.cos(sunriseAngle) * srLabelR;
-        const srLabelY = this.centerY + Math.sin(sunriseAngle) * srLabelR;
-        this.ctx.fillText(label, srLabelX, srLabelY);
+        const sunriseLabelRadius = outerRingRadius + 28;
+        const sunriseLabelX = this.centerX + Math.cos(sunriseAngle) * sunriseLabelRadius;
+        const sunriseLabelY = this.centerY + Math.sin(sunriseAngle) * sunriseLabelRadius;
+        this.ctx.fillText(label, sunriseLabelX, sunriseLabelY);
       }
       
       // Sunrise line connecting rings
@@ -323,10 +323,10 @@ class FrontFace {
         this.ctx.fillStyle = 'rgba(240, 230, 210, 0.9)';
         this.ctx.textAlign = 'center';
         this.ctx.textBaseline = 'middle';
-        const ssLabelR = outerRingRadius + 36;
-        const ssLabelX = this.centerX + Math.cos(sunsetAngle) * ssLabelR;
-        const ssLabelY = this.centerY + Math.sin(sunsetAngle) * ssLabelR;
-        this.ctx.fillText(label, ssLabelX, ssLabelY);
+        const sunsetLabelRadius = outerRingRadius + 36;
+        const sunsetLabelX = this.centerX + Math.cos(sunsetAngle) * sunsetLabelRadius;
+        const sunsetLabelY = this.centerY + Math.sin(sunsetAngle) * sunsetLabelRadius;
+        this.ctx.fillText(label, sunsetLabelX, sunsetLabelY);
       }
       
       // Daylight arc (between sunrise and sunset on outer ring)


### PR DESCRIPTION
## Summary

Simplifies `showSunriseSunset` boolean checks in `FrontFace.js` to match the pattern used by other settings (`rotate`, `theme`, `layout`, `mount`).

## Changes

### Commit 1: Simplify Boolean Checks
- Removed unnecessary `!!` coercion
- Removed duplicate `showLabels2` variable
- Added `|| false` default fallback
- Pattern now consistent with other settings

### Commit 2: Professional Variable Naming
- `srLabelR/X/Y` → `sunriseLabelRadius/X/Y`
- `ssLabelR/X/Y` → `sunsetLabelRadius/X/Y`
- Maintains consistency with existing naming (`sunriseAngle`, `sunsetAngle`, etc.)

## Testing

✅ All tests passing (78 passed, 2 skipped)  
✅ Manually tested in browser console:  
- `window.appSettings.showSunriseSunset = false` - Labels disappear
- `window.appSettings.showSunriseSunset = true` - Labels reappear

## Technical Documentation

Comprehensive technical reference added to issue #49 documenting:
- Visual elements and naming conventions
- Variable relationships and coordinate system
- Data flow and control logic
- Common issues and troubleshooting
- Testing commands

This documentation will serve as a reference for future debugging work.

## Related Issues

Fixes #49

---

**Files Changed:** 1  
**Lines Changed:** +11, -12  
**Commits:** 2