### PR TITLE
CLI: allow negative control location coordinates

### DIFF
--- a/cli/e2e/cli.e2e.test.js
+++ b/cli/e2e/cli.e2e.test.js
@@ -36,6 +36,30 @@ describe('CLI unified registry + adapter', () => {
     expect(data).toHaveProperty('moon');
   });
 
+  test('control location accepts negative latitude/longitude without unknown option error', () => {
+    const { code, stderr } = runCli(
+      [
+        'control',
+        'location',
+        '-4.2333,-38.5000',
+        '--timezone',
+        'America/Fortaleza',
+        '--name',
+        'Sobral, Brazil'
+      ],
+      {
+        ANTIKYTHERA_CONTROL_TOKEN: 'dummy-token',
+        ANTIKYTHERA_API_BASE: 'http://127.0.0.1:65535'
+      }
+    );
+    // We expect the command to reach our control handler (and likely fail with a network error),
+    // but we must not see Commander complaining about an unknown option for the coordinates.
+    expect(stderr).not.toMatch(/unknown option '-4\.2333,-38\.5000'/i);
+    // When the handler runs, it should emit an Error: message from control.js
+    expect(code).not.toBe(0);
+    expect(stderr || '').toMatch(/Error:/i);
+  });
+
   test('position moon --format json with explicit date works via adapter', () => {
     const { code, stdout } = runCli(['position', 'moon', '--format', 'json', '--date', '2025-01-01T00:00:00Z']);
     expect(code).toBe(0);


### PR DESCRIPTION
## Summary

Fix `antikythera control location` so that negative latitude/longitude coordinates (southern/western hemisphere) are accepted when passed as the `<lat,lon>` positional value, and add CLI e2e coverage.

Previously, commands like:

```bash
antikythera control location -4.2333,-38.5000 --timezone "America/Fortaleza" --name "Sobral, Brazil"
```

would fail at the Commander layer with:

```text
error: unknown option '-4.2333,-38.5000'
```

Commander treated the optional positional `[value]` as missing, and interpreted the negative coordinate as an unknown option. The control implementation itself already supports negative coordinates; it just never saw them.

## Changes

### CLI adapter

**File:** `cli/adapters/cli-adapter.js`

- For the unified `control` command, relax Commander option parsing and explicitly recover the value positional from raw args when it starts with `-`:
  - Call `cmd.allowUnknownOption(true)` for `control` so Commander does not immediately exit on `-4.2333,-38.5000`.
  - In the `cmd.action` handler, use `cmdObj.args` (Commander raw args) to reconstruct:
    - `action` from `args[0]` if not already mapped.
    - `value` from `args[1]` when Commander did not bind the optional `[value]` (e.g., because it looks like an option).
- This logic is scoped strictly to the `control` command so other commands retain strict option handling.

### CLI e2e test

**File:** `cli/e2e/cli.e2e.test.js`

- Add a regression test to ensure negative coordinates are no longer treated as an unknown option:

  - Command under test:

    ```bash
    antikythera control location -4.2333,-38.5000 \
      --timezone "America/Fortaleza" \
      --name "Sobral, Brazil"
    ```

  - The test runs the CLI with a dummy control token and an unreachable API base; it asserts that:

    - `stderr` **does not** contain `unknown option '-4.2333,-38.5000'`.
    - The process exits non-zero and `stderr` contains `Error:` (coming from `cli/commands/control.js`, i.e., we reached our handler and attempted the HTTP call).

## Rationale

- The control command already supports negative coordinates at the implementation layer (`control.js` parses `latitude`/`longitude` and validates ranges). The problem was purely at the Commander parsing layer for the optional positional value.
- This change allows all four quadrants of coordinates (N/S/E/W) to work via the positional `<lat,lon>` without requiring quoting or `--coords`, while keeping the fix minimal and localized to the `control` command.

## Testing

- Ran targeted CLI e2e tests:

  ```bash
  npm test -- cli/e2e/cli.e2e.test.js
  ```

  Results:

  - `cli/e2e/cli.e2e.test.js`: 3 tests passed
    - `now --format json returns valid JSON with key fields`
    - `control location accepts negative latitude/longitude without unknown option error`
    - `position moon --format json with explicit date works via adapter`

- Full test suite also passes via pre-push hooks (10 suites passed, 1 skipped; 93 tests passed, 7 skipped).

## Notes

- Alternate syntax using `--coords <lat,lon>` already handled negative coordinates; this PR brings the primary `<lat,lon>` positional path in line with that behavior.
- No changes were required to server-side validation; it still enforces `latitude in [-90, 90]` and `longitude in [-180, 180]`.