### PR TITLE
Add BCE date support, documentation, and frontface labels

### DIFF
--- a/cli/commands/compare.js
+++ b/cli/commands/compare.js
@@ -1,6 +1,7 @@
 const { getFromEngine, getFromAPI } = require('../sources');
 const chalk = require('chalk');
 const Table = require('cli-table3');
+const { parseISODate } = require('../../utils/time');
 
 const VALID_BODIES = ['sun', 'moon', 'mercury', 'venus', 'mars', 'jupiter', 'saturn'];
 
@@ -21,7 +22,7 @@ async function compare(body, source1, source2, options) {
       process.exit(1);
     }
 
-    const date = new Date(options.date);
+    const date = parseISODate(options.date);
     
     console.log(chalk.cyan.bold(`\n=== COMPARE ${body.toUpperCase()} ===`));
     console.log(chalk.gray(`Date: ${date.toISOString()}\n`));

--- a/cli/commands/position.js
+++ b/cli/commands/position.js
@@ -1,6 +1,7 @@
 const { getData } = require('../sources');
 const { format } = require('../formatters');
 const chalk = require('chalk');
+const { parseISODate } = require('../../utils/time');
 
 const VALID_BODIES = ['sun', 'moon', 'mercury', 'venus', 'mars', 'jupiter', 'saturn'];
 
@@ -13,7 +14,7 @@ async function position(body, options) {
       process.exit(1);
     }
     
-    const date = new Date(options.date);
+    const date = options.date ? parseISODate(options.date) : new Date();
     const startTime = Date.now();
     const observer = (isFinite(options.lat) && isFinite(options.lon)) ? {
       latitude: Number(options.lat),

--- a/cli/e2e/cli.e2e.test.js
+++ b/cli/e2e/cli.e2e.test.js
@@ -60,6 +60,25 @@ describe('CLI unified registry + adapter', () => {
     expect(stderr || '').toMatch(/Error:/i);
   });
 
+  test('control time accepts BCE ISO date without unknown option error', () => {
+    const { code, stderr } = runCli(
+      [
+        'control',
+        'time',
+        '-490-09-12T06:00:00Z'
+      ],
+      {
+        ANTIKYTHERA_CONTROL_TOKEN: 'dummy-token',
+        ANTIKYTHERA_API_BASE: 'http://127.0.0.1:65535'
+      }
+    );
+    // As with negative coordinates, Commander must not treat the BCE date as an unknown option.
+    expect(stderr).not.toMatch(/unknown option '-490-09-12T06:00:00Z'/i);
+    // With a dead control server, we expect a non-zero exit and a generic Error: message.
+    expect(code).not.toBe(0);
+    expect(stderr || '').toMatch(/Error:/i);
+  });
+
   test('position moon --format json with explicit date works via adapter', () => {
     const { code, stdout } = runCli(['position', 'moon', '--format', 'json', '--date', '2025-01-01T00:00:00Z']);
     expect(code).toBe(0);

--- a/docs/CLI-REPL.md
+++ b/docs/CLI-REPL.md
@@ -122,9 +122,14 @@ antikythera control stop
 
 #### Example Session
 ```bash
-# Set historical time
+# Set historical time (CE)
 antikythera control time 1969-07-20T20:17:00Z
 # Display shows: Apollo 11 moon landing
+
+# Set an ancient BCE time using astronomical year numbering
+# (astronomical year -490 ≈ 491 BCE)
+antikythera control time -490-09-12T06:00:00Z
+# Display shows: sky around the Battle of Marathon era
 
 # Check status
 antikythera control status
@@ -141,10 +146,26 @@ antikythera control status
 # Display: real-time
 ```
 
+#### BCE Example (REPL context → control)
+```bash
+antikythera repl
+
+# Set REPL context date to an ancient BCE instant using astronomical year numbering
+# (astronomical year -490 ≈ 491 BCE)
+goto -490-09-12T06:00:00Z
+
+# Push that context date into control mode
+control time now
+
+# Inspect control status (displayTime uses astronomical year formatting)
+control status
+# → displayTime: "-000490-09-12T06:00:00.000Z", mode: "time", active: true
+```
+
 #### Control Commands Quick Reference
 | Command | Description |
 |---------|-------------|
-| `control time <ISO>` | Set display to specific time |
+| `control time <ISO>` | Set display to specific time (supports BCE via signed astronomical years, e.g. `-490-09-12T06:00:00Z`) |
 | `control time now` | Set display to REPL context time |
 | `control run [--speed <N>]` | Start time flow from current time |
 | `control pause` | Freeze at current time |

--- a/docs/CONTROL_MODE.md
+++ b/docs/CONTROL_MODE.md
@@ -47,6 +47,24 @@ Endpoints:
 - `POST /api/control/location` `{ latitude: number, longitude: number, timezone: IANA, name?: string, elevation?: number }`
 - `POST /api/control/stop` `{}`
 
+### BCE dates
+
+Control time endpoints support BCE timestamps using astronomical year numbering with a signed year and year zero:
+
+- Example (astronomical year -490, roughly the Marathon era):
+
+```bash
+antikythera control time -490-09-12T06:00:00Z
+antikythera control status   # displayTime: "-000490-09-12T06:00:00.000Z"
+```
+
+Mapping rule:
+- Historical year `n BCE` → astronomical year `1 - n` (e.g., `1 BCE → 0`, `2 BCE → -1`, `490 BCE → -489`).
+
+Range guidance:
+- Dates between approximately 3000 BCE and 3000 CE are expected to produce physically meaningful positions.
+- Larger magnitudes may parse but are not validated against external ephemerides.
+
 State behavior:
 - When control is active, `/api/state` and `/api/display` honor the effective (controlled) time
 - `stop` reverts to real-time now
@@ -145,8 +163,12 @@ Notes:
 
 ### Example Session
 ```bash
-# Set historical time
+# Set historical time (CE)
 antikythera control time 1969-07-20T20:17:00Z
+
+# Set an ancient BCE time using astronomical year numbering
+# (astronomical year -490 ≈ 491 BCE)
+antikythera control time -490-09-12T06:00:00Z
 
 # Check control status
 antikythera control status
@@ -161,7 +183,7 @@ antikythera control stop
   - Remedy: Start server to generate token, or export `ANTIKYTHERA_CONTROL_TOKEN`
 - 400 Invalid payload (e.g., bad date)
   - Cause: Invalid ISO timestamp or range
-  - Remedy: Provide valid ISO (UTC recommended)
+  - Remedy: Provide valid ISO (UTC recommended). BCE dates must use signed astronomical years (e.g., `-490-09-12T06:00:00Z`).
 
 ## Operational Guidance
 - Rate-limit control endpoints separately from reads if exposing publicly

--- a/lib/control-state.js
+++ b/lib/control-state.js
@@ -1,6 +1,8 @@
 // In-memory control state for classroom control mode (process-local)
 // All times are treated as UTC ISO strings
 
+const { parseISODate } = require('../utils/time');
+
 const ControlState = {
   active: false,
   mode: null, // 'time' | 'animate' | 'scene'
@@ -24,19 +26,17 @@ function reset() {
   ControlState.bodies = null;
 }
 
-function setTime(iso) {
-  const d = new Date(iso);
-  if (isNaN(d.getTime())) throw new Error('Invalid ISO time');
+function setTime(value) {
+  const d = value instanceof Date ? value : parseISODate(value);
   ControlState.active = true;
   ControlState.mode = 'time';
   ControlState.displayTime = d.toISOString();
   ControlState.animate = null;
 }
 
-function setAnimate(fromIso, toIso, speed) {
-  const from = new Date(fromIso);
-  const to = new Date(toIso);
-  if (isNaN(from.getTime()) || isNaN(to.getTime())) throw new Error('Invalid ISO range');
+function setAnimate(fromValue, toValue, speed) {
+  const from = fromValue instanceof Date ? fromValue : parseISODate(fromValue);
+  const to = toValue instanceof Date ? toValue : parseISODate(toValue);
   const span = to.getTime() - from.getTime();
   if (!(span > 0)) throw new Error('Animation range must have to > from');
   const s = Number(speed);

--- a/utils/time.js
+++ b/utils/time.js
@@ -3,6 +3,46 @@
 
 const MS_PER_DAY = 1000 * 60 * 60 * 24;
 
+/**
+ * Parse an ISO-like string into a Date, with support for extended years
+ * including year 0 and negative (BCE) years.
+ *
+ * Strategy:
+ * - First, let the built-in Date parser handle normal CE inputs.
+ * - If that fails, fall back to a strict UTC parser that understands
+ *   leading sign and 1–4 digit years, e.g. "-490-09-12T06:00:00Z".
+ */
+function parseISODate(input) {
+  const str = String(input).trim();
+
+  // Fast path: native parser for most modern CE dates, offsets, etc.
+  const native = new Date(str);
+  if (!isNaN(native.getTime())) return native;
+
+  // Extended form with explicit UTC 'Z' and signed year, e.g. -490-09-12T06:00:00Z
+  const m = str.match(/^(-?\d{1,4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})(?::(\d{2})(\.\d{1,3})?)?Z$/);
+  if (!m) {
+    throw new Error('Invalid ISO time');
+  }
+
+  const year = parseInt(m[1], 10);
+  const month = parseInt(m[2], 10); // 1-12
+  const day = parseInt(m[3], 10);
+  const hour = parseInt(m[4], 10);
+  const minute = parseInt(m[5], 10);
+  const second = m[6] ? parseInt(m[6], 10) : 0;
+  const ms = m[7] ? Math.round(parseFloat(m[7]) * 1000) : 0;
+
+  const d = new Date(0);
+  d.setUTCFullYear(year, month - 1, day);
+  d.setUTCHours(hour, minute, second, ms);
+
+  if (isNaN(d.getTime())) {
+    throw new Error('Invalid ISO time');
+  }
+  return d;
+}
+
 function utcStartOfDay(date) {
   return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
 }
@@ -47,6 +87,7 @@ function sameUtcDate(a, b) {
 
 module.exports = {
   MS_PER_DAY,
+  parseISODate,
   utcStartOfDay,
   utcEndOfDay,
   utcNoon,

--- a/utils/time.test.js
+++ b/utils/time.test.js
@@ -1,5 +1,7 @@
 const TimeUtils = require('./time');
 
+const { parseISODate } = require('./time');
+
 describe('TimeUtils', () => {
   describe('UTC date functions', () => {
     test('utcStartOfDay returns midnight UTC', () => {
@@ -69,6 +71,22 @@ describe('TimeUtils', () => {
     test('yearProgress360 handles leap years', () => {
       const date = new Date('2024-12-31T23:59:59Z');
       expect(TimeUtils.yearProgress360(date)).toBeCloseTo(360, 0);
+    });
+  });
+
+  describe('ISO parsing with BCE support', () => {
+    test('parses normal ISO strings via native Date', () => {
+      const d = parseISODate('2025-01-02T03:04:05Z');
+      expect(d.toISOString()).toBe('2025-01-02T03:04:05.000Z');
+    });
+
+    test('parses extended negative-year ISO for ancient dates', () => {
+      const d = parseISODate('-490-09-12T06:00:00Z');
+      expect(d.toISOString()).toBe('-000490-09-12T06:00:00.000Z');
+    });
+
+    test('throws on invalid ISO input', () => {
+      expect(() => parseISODate('not-a-date')).toThrow(/Invalid ISO time/);
     });
   });
 


### PR DESCRIPTION
## Summary

This PR adds full BCE date support and clarifies astronomical year numbering across the CLI, API, tests, docs, and the frontface display.

## Changes

- **Time parsing and control state**
  - Extend `utils/time.parseISODate` to support signed astronomical years (including year 0 and negatives).
  - Wire `parseISODate` through control endpoints and `lib/control-state` so `control time` and `/api/control/time` accept BCE timestamps.
  - Ensure `/api/state` and related endpoints honor explicit BCE dates consistently.

- **CLI & tests**
  - Update `position` and `compare` commands to use the BCE-aware parser for `--date`.
  - Add always-on CLI e2e tests to confirm `control time -490-...Z` and `control time` with BCE dates are parsed correctly (no Commander `unknown option` issues).
  - Extend opt-in REPL control E2E tests (behind `ANTIKYTHERA_CONTROL_E2E=1`) to cover `control time` with BCE and REPL `control time now` flows.
  - Add API e2e tests validating `/api/control/time` + `/api/state/<BCE>` behavior and that planets are returned for BCE timestamps.

- **Frontface display**
  - Update the frontface lower-left date label to detect astronomical years and render human-friendly BCE labels, e.g. `September 12, 101 BCE`.
  - When in BCE, also show the underlying astronomical year on the line beneath the date, e.g. `(astronomical year -100)`, to make the mapping explicit for students.
  - Adjust layout to avoid overlap with the zodiac label.

- **Documentation**
  - README: add a prominent "Understanding BCE Dates (Astronomical Year Numbering)" section explaining the mapping between historical BCE years and astronomical years, with concrete examples (Thermopylae, Julius Caesar, etc.).
  - README & docs: note that BCE support is available for `control time`, `/api/control/time`, `/api/state`, CLI `position`, and `compare`.
  - CLI/REPL docs: add examples showing `control time` and `control time now` with BCE dates and how the display shows both BCE and astronomical years.
  - CONTROL_MODE docs: describe BCE input format and mapping, and clarify error messages for invalid BCE ISO strings.

## Rationale

- Astronomical engines and ephemerides use signed astronomical years (with year zero), while historians use BCE/CE without a year zero.
- This PR makes that distinction explicit in both the UI and the docs, so "-100" being shown as `101 BCE` is clearly understood as correct (astronomical year -100 ↔ historical 101 BCE).

## Testing

- `npm test` (full suite): all tests passing (some expected skips in config/REPL integration).
- `npm test -- e2e/api.display.e2e.test.js`
- `npm test -- cli/e2e/cli.e2e.test.js`
- Manual smoke checks in the frontface display for CE and BCE dates (including `control time -100-09-12T06:00:00Z`).