### PR TITLE
feat(api): add coordinate_frames metadata to /api/sun, /api/moon, /api/planets (#96)

### DIFF
--- a/e2e/api.single-body.e2e.test.js
+++ b/e2e/api.single-body.e2e.test.js
@@ -1,0 +1,149 @@
+// /api/sun, /api/moon, /api/planets coordinate_frames metadata — refs #96.
+//
+// Unlike api.display.e2e.test.js (which reuses a dev server on :3000 when
+// present), this file always spawns its own server on TEST_PORT. The reuse
+// pattern is unsafe for any test that asserts new response shape — a
+// running dev server may be on stale code and silently fail the test for
+// the wrong reason. The isolated port avoids that class of confusion.
+// We exercise the three single-body endpoints and assert the top-level
+// `coordinate_frames` map matches the spec from #96 Option A.
+
+const { spawn } = require('child_process');
+const fetch = require('node-fetch');
+
+jest.setTimeout(30000);
+
+// Spawn the server under test on an isolated port so we never reuse a
+// developer's running dev server (which would test the wrong code).
+// 3099 is well outside the default 3000 and the typical dev range.
+const TEST_PORT = 3099;
+const BASE_URL = `http://localhost:${TEST_PORT}`;
+
+let server;
+
+async function waitForServer(proc) {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      reject(new Error('Server did not start within timeout'));
+    }, 10000);
+
+    function onData(data) {
+      const msg = data.toString();
+      if (msg.includes('Antikythera Engine API running')) {
+        clearTimeout(timeout);
+        proc.stdout.off('data', onData);
+        resolve();
+      }
+    }
+
+    proc.stdout.on('data', onData);
+    proc.stderr.on('data', () => {});
+    proc.on('exit', (code) => {
+      clearTimeout(timeout);
+      reject(new Error(`Server exited early with code ${code}`));
+    });
+  });
+}
+
+beforeAll(async () => {
+  server = spawn('node', ['server.js'], {
+    env: {
+      ...process.env,
+      PORT: String(TEST_PORT),
+      OBSERVER_LATITUDE: '37.5',
+      OBSERVER_LONGITUDE: '23.0',
+      OBSERVER_CITY: 'Athens',
+      OBSERVER_COUNTRY: 'Greece',
+    },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  await waitForServer(server);
+});
+
+afterAll(() => {
+  if (server && !server.killed) {
+    server.kill('SIGINT');
+  }
+});
+
+// The map values are the canonical frame identifiers for these three frames.
+// Keep this expectation in lockstep with engine.js's SINGLE_BODY_COORDINATE_FRAMES.
+const EXPECTED_FRAMES = {
+  ecliptic: 'ecliptic_j2000',
+  equatorial: 'equatorial_j2000',
+  horizontal: 'topocentric_apparent',
+};
+
+describe.each([
+  ['/api/sun'],
+  ['/api/moon'],
+  ['/api/planets'],
+])('%s', (path) => {
+  let body;
+
+  beforeAll(async () => {
+    const res = await fetch(`${BASE_URL}${path}`);
+    expect(res.ok).toBe(true);
+    body = await res.json();
+  });
+
+  test('response carries a top-level coordinate_frames map', () => {
+    expect(body).toHaveProperty('coordinate_frames');
+    expect(typeof body.coordinate_frames).toBe('object');
+    expect(body.coordinate_frames).not.toBeNull();
+  });
+
+  test('coordinate_frames has exactly the three expected keys with correct values', () => {
+    expect(body.coordinate_frames).toEqual(EXPECTED_FRAMES);
+  });
+
+  test('coordinate_frames keys are bare (no "bodies." prefix on single-body endpoints)', () => {
+    // Issue #96 Option A: the body IS the response, so the `bodies.` prefix
+    // used on /api/state's map becomes redundant here.
+    expect(body.coordinate_frames).not.toHaveProperty('bodies.ecliptic');
+    expect(body.coordinate_frames).not.toHaveProperty('bodies.equatorial');
+    expect(body.coordinate_frames).not.toHaveProperty('bodies.horizontal');
+  });
+
+  test('zodiac / lunarNodes / sunVisibility / equationOfTime frames are absent', () => {
+    // These don't appear in single-body responses, so they don't appear in
+    // the frames map for these endpoints either.
+    expect(body.coordinate_frames).not.toHaveProperty('zodiac');
+    expect(body.coordinate_frames).not.toHaveProperty('lunarNodes');
+    expect(body.coordinate_frames).not.toHaveProperty('sunVisibility.horizontal');
+    expect(body.coordinate_frames).not.toHaveProperty('equationOfTime.apparentSun');
+  });
+});
+
+test('/api/sun still returns body data alongside coordinate_frames (no breaking shape change)', async () => {
+  const res = await fetch(`${BASE_URL}/api/sun`);
+  expect(res.ok).toBe(true);
+  const body = await res.json();
+  // Existing fields stay top-level — coordinate_frames is purely additive.
+  expect(typeof body.longitude).toBe('number');
+  expect(typeof body.latitude).toBe('number');
+  expect(typeof body.rightAscension).toBe('number');
+  expect(typeof body.declination).toBe('number');
+});
+
+test('/api/moon still returns body data alongside coordinate_frames (no breaking shape change)', async () => {
+  const res = await fetch(`${BASE_URL}/api/moon`);
+  expect(res.ok).toBe(true);
+  const body = await res.json();
+  expect(typeof body.longitude).toBe('number');
+  expect(typeof body.phase).toBe('number');
+  expect(typeof body.illumination).toBe('number');
+});
+
+test('/api/planets still returns per-planet data alongside coordinate_frames (no breaking shape change)', async () => {
+  const res = await fetch(`${BASE_URL}/api/planets`);
+  expect(res.ok).toBe(true);
+  const body = await res.json();
+  // Each known planet still appears at the top level. coordinate_frames is
+  // a sibling key on this collection-shaped endpoint — consumers iterating
+  // planets must skip it (documented in #96).
+  for (const planet of ['mercury', 'venus', 'mars', 'jupiter', 'saturn']) {
+    expect(body).toHaveProperty(planet);
+    expect(typeof body[planet].longitude).toBe('number');
+  }
+});

--- a/engine.js
+++ b/engine.js
@@ -39,6 +39,18 @@ const COORDINATE_FRAMES = Object.freeze({
   'equationOfTime.apparentSun': 'ecliptic_j2000'
 });
 
+// Subset of COORDINATE_FRAMES used by /api/sun, /api/moon, /api/planets.
+// Those endpoints return body-only data — three frames are in play
+// (ecliptic, equatorial, horizontal) and the `bodies.` prefix becomes
+// redundant because the body IS the response. zodiac, lunarNodes,
+// sunVisibility.*, equationOfTime.* don't appear on single-body responses
+// and so don't appear here. Refs #96.
+const SINGLE_BODY_COORDINATE_FRAMES = Object.freeze({
+  'ecliptic': 'ecliptic_j2000',
+  'equatorial': 'equatorial_j2000',
+  'horizontal': 'topocentric_apparent'
+});
+
 class AntikytheraEngine {
   /**
    * Convert an equator-of-date vector to J2000 mean ecliptic angles
@@ -799,3 +811,4 @@ class AntikytheraEngine {
 
 module.exports = AntikytheraEngine;
 module.exports.COORDINATE_FRAMES = COORDINATE_FRAMES;
+module.exports.SINGLE_BODY_COORDINATE_FRAMES = SINGLE_BODY_COORDINATE_FRAMES;

--- a/server.js
+++ b/server.js
@@ -8,6 +8,7 @@ const { getObserverFromRequest } = require('./lib/location-service');
 const { effectiveDate, status: controlStatus, setTime: controlSetTime, setAnimate: controlSetAnimate, setScene: controlSetScene, run: controlRun, pause: controlPause, stop: controlStop, setLocation: controlSetLocation } = require('./lib/control-state');
 const { getConfigLoader } = require('./lib/config-loader');
 const AntikytheraEngine = require('./engine');
+const { SINGLE_BODY_COORDINATE_FRAMES } = require('./engine');
 const { parseISODate } = require('./utils/time');
 
 const app = express();
@@ -16,7 +17,10 @@ const engine = new AntikytheraEngine();
 // Initialize configuration system
 const configLoader = getConfigLoader();
 const config = configLoader.getConfig();
-const PORT = config.server.port || 3000;
+// PORT resolution order: explicit env var → config file → default 3000.
+// The env-var override lets test files spawn isolated servers without
+// colliding with a developer's running instance on the configured port.
+const PORT = parseInt(process.env.PORT, 10) || config.server.port || 3000;
 
 // Listen for config reload events
 configLoader.on('reload', () => {
@@ -123,7 +127,7 @@ app.get('/api/sun', async (req, res) => {
     const currentConfig = configLoader.getConfig();
     const observer = await getObserverFromRequest(req, currentConfig);
     const state = engine.getState(date, observer.latitude, observer.longitude, observer);
-    res.json(state.sun);
+    res.json({ coordinate_frames: SINGLE_BODY_COORDINATE_FRAMES, ...state.sun });
   } catch (err) {
     res.status(500).json({ error: err.message });
   }
@@ -136,7 +140,7 @@ app.get('/api/moon', async (req, res) => {
     const currentConfig = configLoader.getConfig();
     const observer = await getObserverFromRequest(req, currentConfig);
     const state = engine.getState(date, observer.latitude, observer.longitude, observer);
-    res.json(state.moon);
+    res.json({ coordinate_frames: SINGLE_BODY_COORDINATE_FRAMES, ...state.moon });
   } catch (err) {
     res.status(500).json({ error: err.message });
   }
@@ -149,7 +153,7 @@ app.get('/api/planets', async (req, res) => {
     const currentConfig = configLoader.getConfig();
     const observer = await getObserverFromRequest(req, currentConfig);
     const state = engine.getState(date, observer.latitude, observer.longitude, observer);
-    res.json(state.planets);
+    res.json({ coordinate_frames: SINGLE_BODY_COORDINATE_FRAMES, ...state.planets });
   } catch (err) {
     res.status(500).json({ error: err.message });
   }


### PR DESCRIPTION
Closes #96.

Completes the loose end #94 explicitly deferred: the top-level `coordinate_frames` map exists on `/api/state` and `/api/display`, but the three single-body slices of that same data — `/api/sun`, `/api/moon`, `/api/planets` — had no frame metadata, leaving the same frame-confusion vulnerability on a smaller surface.

## What changes

Pure additive. No existing field changes, no shape break. Each of the three endpoints now returns a top-level `coordinate_frames` map containing exactly the three frames their data uses:

```json
{
  "coordinate_frames": {
    "ecliptic": "ecliptic_j2000",
    "equatorial": "equatorial_j2000",
    "horizontal": "topocentric_apparent"
  },
  "longitude": 280.123,
  "latitude": 0.001,
  ...
}
```

Keys drop the `bodies.` prefix used on the parent endpoints — the issue's Option A spec, on the reasoning that on a single-body endpoint, the body IS the response and the prefix is redundant. Zodiac / lunarNodes / sunVisibility / equationOfTime frames are absent because those concepts don't appear in single-body responses.

For `/api/planets` (a collection-shaped endpoint), `coordinate_frames` is a sibling top-level key alongside `mercury`, `venus`, etc. Consumers iterating planet names must skip it. Called out in the issue.

## Implementation

- **`engine.js`**: new `SINGLE_BODY_COORDINATE_FRAMES` frozen constant next to the existing `COORDINATE_FRAMES`, exported on `module.exports`. Lives next to the existing constant so future frame additions stay co-located.
- **`server.js`**: the three handlers spread `coordinate_frames` as the first key of the response, matching the placement convention used by `engine.getState()`.
- **`server.js` (minor)**: `PORT` env-var override added (`process.env.PORT || config.server.port || 3000`). Standard Node/Express convention; was overdue. Needed by the new e2e test file to spawn an isolated server.

## Tests

`e2e/api.single-body.e2e.test.js` (new, 149 lines, 15 test cases):

- For each of the three endpoints, asserts:
  - top-level `coordinate_frames` present
  - exactly `{ecliptic, equatorial, horizontal}` keys with the correct frame-identifier values
  - no `bodies.*` prefix (per Option A)
  - no `zodiac` / `lunarNodes` / `sunVisibility` / `equationOfTime` keys (absent on single-body responses)
- Plus three shape-regression tests confirming existing body fields are still top-level.

The new test file deliberately does **not** reuse the `localhost:3000` reuse-probe pattern that `api.display.e2e.test.js` uses, because that pattern silently tests stale code when a developer's dev server is running. This file spawns its own server on `PORT=3099` for isolation.

**156/156 tests pass** (was 141, this PR adds 15 new tests).

## Out of scope

- `?frame=` query parameter for dual-frame override (that's #97, which this PR explicitly unblocks).
- Schema/OpenAPI files (none exist in the repo today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)